### PR TITLE
Verpluginv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,14 +274,14 @@ Specifying a [`resolutions`](https://yarnpkg.com/lang/en/docs/selective-version-
 
 Similar to `resolve.alias`, because you can get outside the guarantees of semantic versioning with this tool, be sure to check that your overall application supports the finalized code in the bundle.
 
-## VersionsPlugin
+## VersionCheckPlugin
 
-The `VersionsPlugin` reports on multiple versions of packages installed in your `node_modules` tree that have version skews and have 2+ files included in your bundle under inspection.
+The `VersionCheckPlugin` validates the versions of packages your bundle under inspection and can provide a verbose report of version(s) of packages included in your bundle. This allows you to control the version(s) of packages in your bundle, preventing unexpected changes in versions.
 
 To start using, add the plugin to your `webpack.config.js` file:
 
 ```js
-const { VersionsPlugin } = require("inspectpack/plugin");
+const { VersionCheckPlugin } = require("inspectpack/plugin");
 
 module.exports = {
   // ...
@@ -300,17 +300,16 @@ module.exports = {
       //
       // **Note**: Uses posix paths for all matching (e.g., on windows `/` not `\`).
       ignoredPackages: undefined,
-      // Display full duplicates information? (Default: `false`)
+      // Display full version report? (Default: `false`)
       verbose: false,
-      // Report version information of duplicate packages only? (Default: `true`)
-      duplicatesOnly: true
+      // List of packages & semver it should adhear to
+      allowedVersions: {
+        'lodash': '^4.0.0'
+      }
     })
   ]
 };
 ```
-
-With `duplicatesOnly` set to `false`, the plugin will report the version of each packages that gets bundled into each asset.
-This allows us to understand the version(s) of each package that is bundled in our assets.
 
 ## Command line tool
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An inspection tool for Webpack frontend JavaScript bundles.
 It is also the engine for the handy [`webpack-dashboard`](https://github.com/FormidableLabs/webpack-dashboard) plugin.
 
 - [DuplicatePlugin](#duplicatesPlugin)
-- [VersionsPlugin](#versionsplugin)
+- [VersionCheckPlugin](#versionCheckPlugin)
 - [Command line tool](#command-line-tool)
   - [`duplicates`](#duplicates)
   - [`versions`](#versions)
@@ -287,9 +287,9 @@ module.exports = {
   // ...
   plugins: [
     // ...
-    new VersionsPlugin({
-      // Emit compilation warning or error? (Default: `false`)
-      emitErrors: false,
+    new VersionCheckPlugin({
+      // Emit compilation warning or error? (Default: `true`)
+      emitErrors: true,
       // Handle all messages with handler function (`(report: string)`)
       // Overrides `emitErrors` output.
       emitHandler: undefined,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/mock-fs": "^4.10.0",
     "@types/node": "^14.0.5",
     "@types/pify": "^3.0.2",
+    "@types/semver": "^7.3.8",
     "@types/semver-compare": "^1.0.1",
     "@types/sinon-chai": "^3.2.4",
     "@types/yargs": "^15.0.5",

--- a/src/plugin/common.ts
+++ b/src/plugin/common.ts
@@ -26,3 +26,8 @@ export const pkgNamePath = (pkgParts: INpmPackageBase[]) => pkgParts.reduce(
   (m, part) => `${m}${m ? " -> " : ""}${part.name}@${part.range}`,
   "",
 );
+
+export const versionpkgNamePath = (pkgParts: INpmPackageBase[]) => pkgParts.reduce(
+  (m, part) => `${m}${m ? " -> " : ""}${part.name}@${part.version}`,
+  "",
+);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,2 +1,2 @@
 export { DuplicatesPlugin } from "./duplicates";
-export { VersionsPlugin } from "./versions";
+export { VersionCheckPlugin } from "./versions";

--- a/src/plugin/versions.ts
+++ b/src/plugin/versions.ts
@@ -1,32 +1,48 @@
 import * as chalk from "chalk";
+import * as semver from "semver";
 import semverCompare = require("semver-compare");
 import { actions } from "../lib";
-import { _packageName, IVersionsData, IVersionsDataAssets } from "../lib/actions/versions";
+import { _packageName, IVersionsData, IVersionsDataAssets, IVersionsPackages, IVersionAction } from "../lib/actions/versions";
 import { numF, sort } from "../lib/util/strings";
-import { pkgNamePath, ICompiler, ICompilation } from "./common";
+import {
+  IDependencies,
+} from "../lib/util/dependencies";
+import { versionpkgNamePath, ICompiler, ICompilation } from "./common"
 
 // ----------------------------------------------------------------------------
 // Interfaces
 // ----------------------------------------------------------------------------
-interface IVersionsPluginConstructor {
-  duplicatesOnly?:boolean;
+
+interface IAllowedVersions{
+  [key: string]: string,
+}
+
+interface IVersionsCheckPluginConstructor {
   verbose?: boolean;
   emitErrors?: boolean;
   emitHandler?: (report: string) => {};
+  allowedVersions?: IAllowedVersions;
   ignoredPackages?: (string | RegExp)[];
+}
+
+interface IDependencyMap {
+  [key: string]: IDependencyMapEntry
+}
+
+interface IDependencyMapEntry {
+  [key: string]: Set<string>
 }
 
 // ----------------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------------
 // return version messages of pkgName
-const getVersions = (assetName: string, pkgName:string, assets: IVersionsDataAssets): string[] => {
-  const data: string[] = [];
-  data.push(chalk`* {cyan ${pkgName}}`);
+const getVersionsInfo = (assetName: string, pkgName:string, assets: IVersionsDataAssets, deduped: boolean = false): string[] => {
+  const versionsInfo: string[] = [];
   Object.keys(assets[assetName].packages[pkgName])
   .sort(semverCompare)
   .forEach((version) => {
-    data.push(chalk`  * {gray ${version}}`);
+    versionsInfo.push(chalk`  {gray * ${version} ${deduped ? '(bundled)' : ''}}`);
     Object.keys(assets[assetName].packages[pkgName][version])
       .sort(sort)
       .forEach((filePath) => {
@@ -35,31 +51,192 @@ const getVersions = (assetName: string, pkgName:string, assets: IVersionsDataAss
           modules,
         } = assets[assetName].packages[pkgName][version][filePath];
 
-        data.push(chalk`    * Num deps: ${numF(skews.length)}, files: ${numF(modules.length)}`);
+        versionsInfo.push(chalk`    * Num deps: ${numF(skews.length)}, files: ${numF(modules.length)}`);
         skews.map((pkgParts) => pkgParts.map((part, i) => Object.assign({}, part, {
             name: chalk[i < pkgParts.length - 1 ? "gray" : "cyan"](part.name),
           })))
-          .map(pkgNamePath)
+          .map(versionpkgNamePath)
           .sort(sort)
-          .forEach((pkgStr) => data.push(`      * ${pkgStr}`));
+          .forEach((pkgStr) => versionsInfo.push(`      * ${pkgStr}`));
       });
     });
-  return data;
+  return versionsInfo;
+}
+
+// return version messages of pkgName that has duplicate input
+const reportDedupVersionInfo = (assetName: string, pkgName:string, assets: IVersionsDataAssets, yarnlockData: any): string[] => {
+  const versionsInfo: string[] = [];
+  versionsInfo.push(...getVersionsInfo(assetName, pkgName, assets, true));
+
+  // There should only be 1 version of the package
+  const versionArray = Object.keys(assets[assetName].packages[pkgName]);
+  const dedupedVersion = versionArray.length === 1 ? versionArray[0]:'';
+  Object.keys(yarnlockData).forEach((version) => {
+    if (version != dedupedVersion) {
+      versionsInfo.push(chalk`  {gray * ${version} (not bundled)}`);
+      yarnlockData[version].forEach((path: string) => {
+        versionsInfo.push(chalk`      * ${path}`);
+      });
+    }
+  });
+
+  return versionsInfo;
+}
+
+// takes a dependency tree and flatten it into a map
+function getDependencyMap(tree: IDependencies, data: IDependencyMap, dependencyLink: string) {
+  if (tree.dependencies) {
+    for (let i = 0; i < tree.dependencies.length; i++) {
+      const key = tree.dependencies[i].name;
+      const dependencyData = tree.dependencies[i];
+      data[key] = data[key] || {};
+      data[key][dependencyData.version] = data[key][dependencyData.version] || new Set();
+      data[key][dependencyData.version].add(chalk `${dependencyLink} -> {gray ${key}}@${dependencyData.version}`);
+      getDependencyMap(dependencyData, data, chalk `${dependencyLink} -> {gray ${key}}@${dependencyData.version}`);
+    }
+  }
+}
+
+// return names of all dependency that has multiple versions in the dependency map
+function findDupsFromDependencyMap(dependencyMap: IDependencyMap): (string[]) {
+  const depNames: string[] = Object.keys(dependencyMap).sort();
+  const dupDependencies: string[] = depNames.filter((depName) => {
+    return Object.keys(dependencyMap[depName]).length > 1;
+  });
+  return dupDependencies;
+}
+
+// returns true if a package version does not match the allowedVersions specified, otherwise, return false
+const isAllowedVersionViolated = (allowedVersions:IAllowedVersions, pkgName: string, packages: IVersionsPackages): boolean => {
+  if (Object.keys(allowedVersions).includes(pkgName)) {
+    const versions = Object.keys(packages[pkgName]);
+    const specifier = allowedVersions[pkgName];
+    return !(specifier === '*' || versions.every(version => semver.satisfies(version, specifier)));
+  }
+  return false;
+}
+
+// analyzes the asset package data & lock file dependency tree, returns:
+// 1. any packages violating version restraints
+// 2. verbose output contains version info of each package.
+/* sample verbose output:
+  Duplicated packages
+  ## `chunk.6d75141a1b34dadb998a.js`
+  * packageY
+    * 0.2.4
+      * Num deps: 1, files: 1
+        * repoName@0.0.0 -> packageX@0.4.0 -> packageY@0.2.4
+    * 0.3.0
+      * Num deps: 2, files: 1
+        * repoName@0.0.0 -> packageZ@1.2.0 -> packageY@0.3.0
+  Deduplicated packages
+  ## `chunk.6d75141a1b34dadb998a.js`
+  * @packageD
+    * 1.0.3 (bundled)
+      * Num deps: 1, files: 2
+        * repoName@0.0.0 -> packageD@1.0.3
+    * 0.3.0 (not bundled)
+        * repoName@0.0.0 -> packageCd@3.0.3 -> packageD@0.3.0
+  Single version packages
+  ## `chunk.6d75141a1b34dadb998a.js`
+  * @packageA
+    * 2.0.1
+      * Num deps: 1, files: 5
+        * repoName@1.0.0 -> packageA@2.0.1
+*/
+function analyzePackageVersions(assets: IVersionsDataAssets, allowedVersionsMap: IAllowedVersions, depTree: (IDependencies | null)[]): {
+  verboseOutput: string[];
+  versionViolations: string[];
+} {
+  const verboseOutput: string[] = [];
+  const dupPkgMsgs: string[] = [];
+  const dedupedPkgMsgs: string[] = [];
+  const singlePkgMsgs: string[] = [];
+  const versionViolations: string[] = [];
+  const dependencyMap: IDependencyMap = {};
+
+  depTree.forEach((dependency) => {
+    if (dependency !== null ){
+      getDependencyMap(dependency, dependencyMap, chalk `{gray ${dependency.name}}@${dependency.version}`);
+    }
+  });
+  const dupDependencies = findDupsFromDependencyMap(dependencyMap);
+
+  Object.keys(assets)
+  .filter((assetName) => Object.keys(assets[assetName].packages).length)
+  .forEach((assetName) => {
+    // For each asset, report duplicated packages, deduplicated packages and single version packages
+    // deduplicate packages are packages that has multiple version for input, while one version gets deduped and bundled in the assets
+    const dupPkgForAsset: string[] = [];
+    const dedupedPkgForAsset: string[] = [];
+    const singlePkgForAsset: string[] = [];
+
+    Object.keys(assets[assetName].packages)
+    .sort(sort)
+    .forEach((pkgName) => {
+      let versionInfo;
+      // if pkgName has multiple versions
+      if (Object.keys(assets[assetName].packages[pkgName]).length > 1) {
+        versionInfo = getVersionsInfo(assetName, pkgName, assets);
+        dupPkgForAsset.push(chalk`* {cyan ${pkgName}}`, ...versionInfo);
+      }
+      // if pkgName a single version, but has multiple versions in the lock file
+      else if (dupDependencies.some(depName => depName === pkgName)) {
+        versionInfo = reportDedupVersionInfo(assetName, pkgName, assets, dependencyMap[pkgName]);
+        dedupedPkgForAsset.push(chalk`* {cyan ${pkgName}}`, ...versionInfo);
+      }
+      // pkgName has a single version
+      else {
+        versionInfo = getVersionsInfo(assetName, pkgName, assets);
+        singlePkgForAsset.push(chalk`* {cyan ${pkgName}}`, ...versionInfo);
+      }
+
+      // validate allowedVersions
+      if (isAllowedVersionViolated(allowedVersionsMap, pkgName, assets[assetName].packages)) {
+        const specifier = allowedVersionsMap[pkgName];
+        versionViolations.push(chalk `{bold.red ${pkgName} - allowed semver: ${specifier}}`)
+        versionViolations.push(...versionInfo);
+      }
+    });
+
+    if (dupPkgForAsset.length > 1) {
+      dupPkgMsgs.push(chalk `{gray ## \`${assetName}\`}`, ...dupPkgForAsset, '');
+    }
+    if (dedupedPkgForAsset.length > 1) {
+      dedupedPkgMsgs.push(chalk `{gray ## \`${assetName}\`}`, ...dedupedPkgForAsset, '');
+    }
+    if (singlePkgForAsset.length > 1) {
+      singlePkgMsgs.push(chalk `{gray ## \`${assetName}\`}`, ...singlePkgForAsset, '');
+    }
+  });
+
+  // summarize everything
+  verboseOutput.push(chalk`{bold.underline Versions info}\n`);
+  verboseOutput.push(chalk`{underline Single version packages}`);
+  (singlePkgMsgs.length > 1) ? verboseOutput.push(...singlePkgMsgs) : verboseOutput.push(chalk`    {green n/a}\n`);
+  if (dedupedPkgMsgs.length > 0) {
+    verboseOutput.push(chalk`{underline Deduplicated packages}`);
+    verboseOutput.push(...dedupedPkgMsgs);
+  }
+  verboseOutput.push(chalk`{underline Duplicate version packages}`);
+  (dupPkgMsgs.length > 1) ? verboseOutput.push(...dupPkgMsgs) : verboseOutput.push(chalk`    {green n/a}\n`);
+
+  return { verboseOutput, versionViolations };
 }
 
 // ----------------------------------------------------------------------------
 // Plugin
 // ----------------------------------------------------------------------------
-export class VersionsPlugin {
-  private opts: IVersionsPluginConstructor;
+export class VersionCheckPlugin {
+  private opts: IVersionsCheckPluginConstructor;
 
-  constructor({duplicatesOnly, verbose, emitErrors, emitHandler, ignoredPackages}: IVersionsPluginConstructor = {}) {
+  constructor({verbose, emitErrors, emitHandler, ignoredPackages, allowedVersions}: IVersionsCheckPluginConstructor = {}) {
     this.opts = {
       emitErrors: emitErrors === true, // default `false`
       emitHandler: typeof emitHandler === "function" ? emitHandler : undefined,
       ignoredPackages: Array.isArray(ignoredPackages) ? ignoredPackages : undefined,
       verbose: verbose === true, // default `false`
-      duplicatesOnly: duplicatesOnly !== false,  // default `true`
+      allowedVersions: allowedVersions,
     };
   }
 
@@ -83,59 +260,48 @@ export class VersionsPlugin {
         source: true // Needed for webpack5+
       });
 
-    const { emitErrors, emitHandler, ignoredPackages, duplicatesOnly } = this.opts;
+    const { emitErrors, emitHandler, ignoredPackages, verbose, allowedVersions } = this.opts;
 
     // Stash messages for output to console (success) or compilation warnings
     // or errors arrays on duplicates found.
-    const msgs: string[] = [];
-    const dupPkgMsgs: string[] = [];
-    const singlePkgMsgs: string[] = [];
+    // TODO: how to not require or empty object/string??
+    const allowedVersionsMap = allowedVersions || {};
+    let versionAction: IVersionAction;
 
     return Promise.resolve()
-      .then(() => actions("versions", { stats, ignoredPackages, duplicatesOnly }))
-      .then((a) => a.getData() as Promise<IVersionsData>)
-      .then((data) => {
-        const { assets } = data;
-        Object.keys(assets)
-        .filter((assetName) => Object.keys(assets[assetName].packages).length)
-        .forEach((assetName) => {
-          // For each asset, report duplicated packages and single version packages seperately
-          const dupPkgForAsset: string[] = [];
-          const singlePkgForAsset: string[] = [];
+      .then(() => actions("versions", { stats, ignoredPackages, duplicatesOnly: false }))
+      .then((a) => {
+        versionAction = a as IVersionAction;
+        return Promise.all([
+          versionAction.getData() as Promise<IVersionsData>,
+          versionAction.allDeps
+        ]);
+      })
+      .then((datas) => {
+        const [ versionsData, allDeps ] = datas;
+        const { verboseOutput, versionViolations } = analyzePackageVersions(versionsData.assets, allowedVersionsMap, allDeps);
+        let report = [];
+        if (versionViolations.length > 0) {
+          report.push(chalk`{bold.underline Versions violations}`);
+          report.push('Inspectpack versionsPlugin found the following packages violating the allowedVersions specified:\n');
+          report.push(...versionViolations);
+        }
 
-          Object.keys(assets[assetName].packages)
-          .sort(sort)
-          .forEach((pkgName) => {
-            if (Object.keys(assets[assetName].packages[pkgName]).length > 1) {
-              dupPkgForAsset.push(...getVersions(assetName, pkgName, assets));
-            } else {
-              singlePkgForAsset.push(...getVersions(assetName, pkgName, assets));
-            }
-          });
-
-          if (dupPkgForAsset.length > 1) {
-            dupPkgMsgs.push(chalk `{gray ## \`${assetName}\`}`, ...dupPkgForAsset, '');
+        if (verbose) {
+          report.unshift(...verboseOutput)
+        }
+        const output = report.join("\n    ");
+        // Drain messages into custom handler or warnings/errors.
+        if (emitHandler) {
+          emitHandler(output);
+        } else {
+          if (emitErrors && versionViolations.length > 0 ) {
+            errors.push(new Error(output));
+          } else {
+            warnings.push(new Error(output));
           }
-          if (singlePkgForAsset.length > 1) {
-            singlePkgMsgs.push(chalk `{gray ## \`${assetName}\`}`, ...singlePkgForAsset, '');
-          }
-        });
-
-      msgs.push(chalk`{bold.underline Versions info} - {bold.yellow ${duplicatesOnly ? 'Duplicates Only': 'All Packages'}}\n`);
-      msgs.push(chalk`{underline Single version packages}`);
-      (singlePkgMsgs.length > 1) ? msgs.push(...singlePkgMsgs) : msgs.push(chalk`    {red n/a}\n`);
-      msgs.push(chalk`{underline Duplicate version packages}`);
-      (dupPkgMsgs.length > 1) ? msgs.push(...dupPkgMsgs) : msgs.push(chalk`    {green n/a}\n`);
-
-      // Drain messages into custom handler or warnings/errors.
-      const report = msgs.join("\n    ");
-      if (emitHandler) {
-        emitHandler(report);
-      } else {
-        const output = emitErrors ? errors : warnings;
-        output.push(new Error(report));
-      }
-    })
+        }
+      })
     // Handle old plugin API callback.
     .then(() => {
       if (callback) { return void callback(); }

--- a/src/plugin/versions.ts
+++ b/src/plugin/versions.ts
@@ -107,7 +107,7 @@ function findDupsFromDependencyMap(dependencyMap: IDependencyMap): (string[]) {
 }
 
 // returns true if a package version does not match the allowedVersions specified, otherwise, return false
-const isAllowedVersionViolated = (allowedVersions:IAllowedVersions, pkgName: string, packages: IVersionsPackages): boolean => {
+export const isAllowedVersionViolated = (allowedVersions:IAllowedVersions, pkgName: string, packages: IVersionsPackages): boolean => {
   if (Object.keys(allowedVersions).includes(pkgName)) {
     const versions = Object.keys(packages[pkgName]);
     const specifier = allowedVersions[pkgName];

--- a/test/lib/plugin/duplicates.spec.ts
+++ b/test/lib/plugin/duplicates.spec.ts
@@ -11,9 +11,9 @@ import * as actionsVersions from "../../../src/lib/actions/versions";
 
 import {
    _getDuplicatesVersionsData,
-   DuplicatesPlugin,
-   ICompilation,
+   DuplicatesPlugin
 } from "../../../src/plugin/duplicates";
+import { ICompilation } from "../../../src/plugin/common";
 
 import * as chalk from "chalk";
 import { IWebpackStats } from "../../../src/lib/interfaces/webpack-stats";

--- a/test/lib/plugin/versioncheck.spec.ts
+++ b/test/lib/plugin/versioncheck.spec.ts
@@ -1,0 +1,102 @@
+// test cases
+// versionCheckPlugin analyze
+// versionCheckPlugin verbose
+// versionCheckPlugin fails
+
+import { expect } from "chai";
+
+import {
+  isAllowedVersionViolated
+} from "../../../src/plugin/versions";
+
+describe("plugin/versionCheck", () => {
+  describe("isAllowedVersionViolated", () => {
+    it('passes when only one version is included with no specifier', () => {
+      const packages = {
+        'my-addon': {
+          '1.2.3': {}
+        }
+      };
+
+      expect(isAllowedVersionViolated({}, 'my-addon', packages)).to.eql(false);
+    });
+
+    it('allows prerelease versions with a `*` specifier', () => {
+      const packages = {
+        'my-addon': {
+          '1.2.3': {},
+          '2.0.0-beta.1': {},
+        }
+      };
+      const allowedVersions = {
+        'my-addon' : '*'
+      }
+
+      expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(false);
+    });
+
+    it('fails when only one version is included that doesn\'t satisfy the specifier', () => {
+      const packages = {
+        'my-addon': {
+          '1.2.3': {}
+        }
+      };
+
+      const allowedVersions = {
+        'my-addon': '^1.2.4',
+      };
+
+      expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(true);
+    });
+
+    it('passes when only one version is included that satisfies the specifier', () => {
+      const packages = {
+        'my-addon': {
+          '1.2.3': {}
+        }
+      };
+
+      const allowedVersions = {
+        'my-addon': '^1.2.0',
+      };
+
+      expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(false);
+    });
+
+    it('fails when multiple versions are included and one doesn\'t satisfy the specifier', () => {
+      const packages = {
+        'my-addon': {
+          '1.2.3': {},
+          '1.4.2': {}
+        },
+        'foo': {
+          '1.0.0': {}
+        }
+      };
+
+      const allowedVersions = {
+        'my-addon': '^1.4.0',
+      };
+
+      expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(true);
+    });
+
+    it('passes when multiple versions are included that satisfy the specifier', () => {
+      const packages = {
+        'my-addon': {
+          '1.4.2': {},
+          '1.4.3': {}
+        },
+        'foo': {
+          '1.0.0': {}
+        }
+      };
+
+      const allowedVersions = {
+        'my-addon': '^1.4.0',
+      };
+
+      expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(false);
+    });
+  });
+});

--- a/test/lib/plugin/versioncheck.spec.ts
+++ b/test/lib/plugin/versioncheck.spec.ts
@@ -114,7 +114,7 @@ describe("plugin/versionCheck", () => {
       expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(false);
     });
   });
-  describe.only("VersionCheckPlugin", () => {
+  describe("VersionCheckPlugin", () => {
     VERSIONS.forEach((vers) => {
       // Mock compilation:
       let compilation: ICompilation;
@@ -222,7 +222,7 @@ describe("plugin/versionCheck", () => {
           (chalk as any).level = origChalkLevel;
         });
 
-        it(`produces a default report`, () => {
+        it(`emits errors when allowedVersions is violated`, () => {
           const plugin = new VersionCheckPlugin({
             allowedVersions: {
               'foo': '^1.2.0'
@@ -239,7 +239,7 @@ describe("plugin/versionCheck", () => {
           });
         });
 
-        it(`produces a verbose report`, () => {
+        it(`emits errors with verbose report when allowedVersions is violated`, () => {
           const plugin = new VersionCheckPlugin({
             allowedVersions: {
               'foo': '^1.2.0'
@@ -273,19 +273,7 @@ describe("plugin/versionCheck", () => {
           });
         });
 
-        it(`produces no report when no violations occur`, () => {
-          const plugin = new VersionCheckPlugin({
-            allowedVersions: {},
-            verbose: false,
-          });
-
-          return plugin.analyze(compilation).then(() => {
-            expect(compilation.warnings).to.eql([]);
-            expect(compilation.errors).to.eql([]);
-          });
-        });
-
-        it(`produces a verbose report`, () => {
+        it(`produces a verbose report with version violation when emitErrors is false`, () => {
           const plugin = new VersionCheckPlugin({
             allowedVersions: {
               'foo': '^1.2.0'
@@ -301,6 +289,35 @@ describe("plugin/versionCheck", () => {
               .to.have.property("0").that
                 .is.an("Error").and
                 .has.property("message", verboseFailureReport);
+          });
+        });
+
+        it(`produces no report when no violations occur`, () => {
+          const plugin = new VersionCheckPlugin({
+            allowedVersions: {},
+            verbose: false,
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.warnings).to.eql([]);
+            expect(compilation.errors).to.eql([]);
+          });
+        });
+
+        it(`ignorePackage ignore packages that would have violated allowedVersions`, () => {
+          const plugin = new VersionCheckPlugin({
+            ignoredPackages:[
+              'foo'
+            ],
+            allowedVersions: {
+              'foo': '^1.2.0'
+            },
+            verbose: false,
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.errors).to.eql([]);
+            expect(compilation.warnings).to.eql([]);
           });
         });
       });

--- a/test/lib/plugin/versioncheck.spec.ts
+++ b/test/lib/plugin/versioncheck.spec.ts
@@ -1,15 +1,30 @@
 // test cases
-// versionCheckPlugin analyze
-// versionCheckPlugin verbose
-// versionCheckPlugin fails
+// versionCheckPlugin does not fail if emitErrors is false
+
+import { join } from "path";
 
 import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { ICompilation } from "../../../src/plugin/common";
+
+import * as chalk from "chalk";
+import { IWebpackStats } from "../../../src/lib/interfaces/webpack-stats";
+import { toPosixPath } from "../../../src/lib/util/files";
+import { IFixtures, loadFixtures, VERSIONS } from "../../utils";
 
 import {
-  isAllowedVersionViolated
+  isAllowedVersionViolated,
+  VersionCheckPlugin
 } from "../../../src/plugin/versions";
 
+const MULTI_SCENARIO = "multiple-resolved-no-duplicates";
+
 describe("plugin/versionCheck", () => {
+  let fixtures: IFixtures;
+
+  before(() => loadFixtures().then((f) => { fixtures = f; }));
+
   describe("isAllowedVersionViolated", () => {
     it('passes when only one version is included with no specifier', () => {
       const packages = {
@@ -98,5 +113,198 @@ describe("plugin/versionCheck", () => {
 
       expect(isAllowedVersionViolated(allowedVersions, 'my-addon', packages)).to.eql(false);
     });
+  });
+  describe.only("VersionCheckPlugin", () => {
+    VERSIONS.forEach((vers) => {
+      // Mock compilation:
+      let compilation: ICompilation;
+      let toJson: () => IWebpackStats;
+
+      // Report outputs
+      let failureReport: string;
+      let verboseFailureReport: string;
+      let verboseReport: string;
+
+      before(async () => {
+        // tslint:disable max-line-length
+        failureReport = `    Versions violations
+    Inspectpack versionsPlugin found the following packages violating the allowedVersions specified:
+
+    foo - allowed semver: ^1.2.0
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> foo@1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-foo@1.1.1 -> foo@1.1.1`;
+
+        verboseReport = `    Versions info
+    Single version packages
+    ## \`bundle-no-duplicates.js\`
+    * more-no-duplicates
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> more-no-duplicates@1.1.1
+    * uses-no-duplicates
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-no-duplicates@1.1.1
+
+    ## \`bundle.js\`
+    * foo
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> foo@1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-foo@1.1.1 -> foo@1.1.1
+    * more-no-duplicates
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> more-no-duplicates@1.1.1
+    * uses-foo
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-foo@1.1.1
+    * uses-no-duplicates
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-no-duplicates@1.1.1
+
+    Duplicate version packages
+    ## \`bundle-no-duplicates.js\`
+    * no-duplicates
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> no-duplicates@1.1.1
+      * 2.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-no-duplicates@1.1.1 -> no-duplicates@2.1.1
+      * 3.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> more-no-duplicates@1.1.1 -> no-duplicates@3.1.1
+
+    ## \`bundle.js\`
+    * no-duplicates
+      * 1.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> no-duplicates@1.1.1
+      * 2.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> uses-no-duplicates@1.1.1 -> no-duplicates@2.1.1
+      * 3.1.1
+        * Num deps: 1, files: 1
+          * multiple-resolved-no-duplicates@1.2.3 -> more-no-duplicates@1.1.1 -> no-duplicates@3.1.1
+`;
+        // tslint:enable max-line-length
+
+        verboseFailureReport = `${verboseReport}\n${failureReport}`;
+      });
+
+      beforeEach(() => {
+        const stats = fixtures[toPosixPath(join(MULTI_SCENARIO, `dist-development-${vers}`))];
+        toJson = sinon.stub().returns(stats);
+        compilation = {
+          errors: [],
+          getStats: () => ({ toJson }),
+          warnings: [],
+        };
+      });
+
+      describe(`v${vers}`, () => {
+        let origChalkLevel: chalk.Level;
+
+        beforeEach(() => {
+          // Stash and disable chalk for tests.
+          origChalkLevel = chalk.level;
+          (chalk as any).level = 0;
+        });
+
+        afterEach(() => {
+          (chalk as any).level = origChalkLevel;
+        });
+
+        it(`produces a default report`, () => {
+          const plugin = new VersionCheckPlugin({
+            allowedVersions: {
+              'foo': '^1.2.0'
+            },
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.warnings).to.eql([]);
+            expect(compilation.errors)
+              .to.have.lengthOf(1).and
+              .to.have.property("0").that
+                .is.an("Error").and
+                .has.property("message", failureReport);
+          });
+        });
+
+        it(`produces a verbose report`, () => {
+          const plugin = new VersionCheckPlugin({
+            allowedVersions: {
+              'foo': '^1.2.0'
+            },
+            verbose: true,
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.warnings).to.eql([]);
+            expect(compilation.errors)
+              .to.have.lengthOf(1).and
+              .to.have.property("0").that
+                .is.an("Error").and
+                .has.property("message", verboseFailureReport);
+          });
+        });
+
+        it(`produces a verbose report when no violations`, () => {
+          const plugin = new VersionCheckPlugin({
+            allowedVersions: {},
+            verbose: true,
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.errors).to.eql([]);
+            expect(compilation.warnings)
+              .to.have.lengthOf(1).and
+              .to.have.property("0").that
+                .is.an("Error").and
+                .has.property("message", verboseReport);
+          });
+        });
+
+        it(`produces no report when no violations occur`, () => {
+          const plugin = new VersionCheckPlugin({
+            allowedVersions: {},
+            verbose: false,
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.warnings).to.eql([]);
+            expect(compilation.errors).to.eql([]);
+          });
+        });
+
+        it(`produces a verbose report`, () => {
+          const plugin = new VersionCheckPlugin({
+            allowedVersions: {
+              'foo': '^1.2.0'
+            },
+            verbose: true,
+            emitErrors: false,
+          });
+
+          return plugin.analyze(compilation).then(() => {
+            expect(compilation.errors).to.eql([]);
+            expect(compilation.warnings)
+              .to.have.lengthOf(1).and
+              .to.have.property("0").that
+                .is.an("Error").and
+                .has.property("message", verboseFailureReport);
+          });
+        });
+      });
+    });
+
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,6 +341,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver-compare/-/semver-compare-1.0.1.tgz#17d1dc62c516c133ab01efb7803a537ee6eaf3d5"
   integrity sha512-wx2LQVvKlEkhXp/HoKIZ/aSL+TvfJdKco8i0xJS3aR877mg4qBHzNT6+B5a61vewZHo79EdZavskGnRXEC2H6A==
 
+"@types/semver@^7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+
 "@types/sinon-chai@^3.2.4":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@types/sinon-chai/-/sinon-chai-3.2.5.tgz#df21ae57b10757da0b26f512145c065f2ad45c48"


### PR DESCRIPTION
Replacing versionPlugin in favor of versionCheckPlugin

VersionCheckPlugin validates the versions of packages your bundle under inspection and can provide a verbose report of version(s) of packages included in your bundle. This allows you to control the version(s) of packages in your bundle, preventing unexpected changes in versions from version bumps of dependencies.

versionPlugin which provides a report of versions of packages in the bundle is part of the versionCheckPlugin.